### PR TITLE
Added  to CSS governing the board component to remove cursor

### DIFF
--- a/src/Board.module.css
+++ b/src/Board.module.css
@@ -12,6 +12,7 @@
   text-align: center;
   border: none;
   margin: 5px;
+  pointer-events: none;
 }
 .board input:focus {
   border: 2px solid black;


### PR DESCRIPTION
## Description

## Before
Cursor shows in the `input` boxes

## After
Blinking cursor does not show in input boxes

## Implementation Details 
Added one line of CSS at end of `.board input` block. 

