### PR TITLE
Issue 57 Hide answer and create "toggle" to hide answers

### DIFF
--- a/src/Board.js
+++ b/src/Board.js
@@ -11,6 +11,7 @@ function Board({ answer }) {
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
   const [gameOver, setGameOver] = useState(false);
+  const [answerVisible, setAnswerVisible] = useState(false);
 
   const handleSubmit = useCallback(
     (e) => {
@@ -161,10 +162,12 @@ function Board({ answer }) {
     handleKeyDown({ key: note });
   }
 
+  function toggleAnswer(){
+    setAnswerVisible(!answerVisible);
+  }
+
   return (
     <>
-      <p>Guess: {JSON.stringify(guess)}</p>
-      <p>Answer: {JSON.stringify(answer)}</p>
       <form className={styles.board} onSubmit={handleSubmit}>
         {guess.map((char, row) => {
           return (
@@ -209,6 +212,12 @@ function Board({ answer }) {
       {message && <div className={styles.modalOverlay}></div>}
 
       <Piano handlePianoPress={handlePianoPress} />
+      <button className={styles.answerButton} onClick={toggleAnswer}>Show answer</button>
+      {answerVisible && <div className={styles.answerBox}>
+        <p>Guess: {JSON.stringify(guess)}</p>
+        <p>Answer: {JSON.stringify(answer)}</p>
+      </div>
+      }
     </>
   );
 }

--- a/src/Board.js
+++ b/src/Board.js
@@ -212,7 +212,7 @@ function Board({ answer }) {
       {message && <div className={styles.modalOverlay}></div>}
 
       <Piano handlePianoPress={handlePianoPress} />
-      <button className={styles.answerButton} onClick={toggleAnswer}>Show answer</button>
+      <button className={styles.answerButton} onClick={toggleAnswer}>{answerVisible ? "Hide answer":"Show answer"}</button>
       {answerVisible && <div className={styles.answerBox}>
         <p>Guess: {JSON.stringify(guess)}</p>
         <p>Answer: {JSON.stringify(answer)}</p>

--- a/src/Board.module.css
+++ b/src/Board.module.css
@@ -114,3 +114,13 @@ input.incorrect {
   width: 100%;
   height: 100%;
 }
+
+.answerButton {
+  background-color: var(--background-lightmode);
+  border: 1px solid var(--wordle-background-color-selected-lightmode);
+  color: var(--text-color-lightmode);
+}
+
+div.answerBox {
+  display: block;
+}


### PR DESCRIPTION
## Description
This PR resolves #57 

## Before
Answer information was prominently placed. 
![image](https://user-images.githubusercontent.com/4889231/167507243-05f41c0d-a1af-4eca-8f59-1015ad3d23c5.png)


## After
Answer information has now been shifted below the piano. Clicking on "Show answers" will show answers. 
![image](https://user-images.githubusercontent.com/4889231/167508383-6c93a095-0cbb-4f12-b522-32acec98ce77.png)


## Implementation Details 
Added some logic in board.js and also added some additional CSS styling to make show answers less prominent and more distinct with respect to the other buttons. 
