### PR TITLE
Instrument selection + "hard" mode only allows 3 plays

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -229,7 +229,7 @@ function Board({ answer, testMode }) {
           break;
       }
     },
-    [answer, gameOver, currentRow, guess, handleSubmit, volume]
+    [answer, gameOver, currentRow, guess, handleSubmit, volume, instrument]
   );
 
 
@@ -372,7 +372,7 @@ function Board({ answer, testMode }) {
         <section className={styles.settings}>
           <div>
             <InputLabel variant="standard" htmlFor="instrument">
-              Instrument {instrument}
+              Instrument 
             </InputLabel>
             <NativeSelect
               defaultValue="acoustic_grand_piano"

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -16,6 +16,9 @@ import ModalStats from './ModalStats';
 import MidnightContext from './contexts/MidnightContext';
 import getNote from './helpers/getNote'
 import ShareResults from './ShareResults'
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+
 
 function Board({ answer, testMode }) {
   const volume = useContext(VolumeContext);
@@ -30,6 +33,7 @@ function Board({ answer, testMode }) {
       return Array(6).fill("⬛");
     })
   );
+  const [playTuneTries, setPlayTuneTries] = useState(3);
   const [difficultyMode, setDifficultyMode] = useState('normal')
   const [isOpen, setIsOpen] = useState(false);
   const [showStatsModal, setShowStatsModal] = useState(false);
@@ -287,15 +291,20 @@ function Board({ answer, testMode }) {
       <Grid item xl={4} lg={5} md={7} className={styles.left}>
         <Paper elevation={0}>
           <button type="button" className={styles.action}
-            onClick={() => {
-              if (difficultyMode === "tricky") {
-                playSequenceFrenchHorn(answer, undefined, undefined, volume);
-              } else {
-                playSequence(answer, undefined, undefined, volume);
+            onClick={(e) => {
+              if (difficultyMode === "difficult") {
+                if (playTuneTries === 0) {
+                  e.preventDefault();
+                  setError("You've maxed out the number of times you can play the tune")
+                  return;
+                } 
+                setPlayTuneTries(playTuneTries-1);
               }
+              playSequence(answer, undefined, undefined, volume);
             }
             }>
-            <FontAwesomeIcon icon={faPlay} /> Play the tune</button>
+            <FontAwesomeIcon icon={faPlay} /> Play the tune {difficultyMode === 'difficult' && `- ${playTuneTries} plays left`}</button>
+
           <form className={styles.board} onSubmit={handleSubmit}>
             {guess.map((char, row) => {
               //char is the same thing as guess[row]
@@ -360,11 +369,23 @@ function Board({ answer, testMode }) {
         <PianoNew handlePianoPress={handlePianoPress} octave={octave} hasFlats={answer?.hasFlats} />
         <hr />
         <p><strong>Difficulty Mode (beta)</strong></p>
-        <select onChange={(e) => setDifficultyMode(e.target.value)} className={styles.difficultyMode}>
+        {/* <select onChange={(e) => setDifficultyMode(e.target.value)} className={styles.difficultyMode}>
           <option value="normal">Normal</option>
           <option value="difficult">Difficult - the "play my guess" buttons are gone</option>
           <option value="tricky">Tricky - we play the tune in French Horn; you guess the notes in piano</option>
-        </select>
+        </select> */}
+        <Select
+          labelId="difficulty-level"
+          id="difficulty-level"
+          label="Difficulty Level"
+          defaultValue="normal"
+          onChange={(e) => setDifficultyMode(e.target.value)}
+          className={styles.difficultyMode}
+          sx={{fontSize: '1.6rem'}}
+        >
+          <MenuItem value="normal">Normal</MenuItem>
+          <MenuItem value="difficult">Difficult - play tune up to 3 times and the "play my guess" buttons are gone</MenuItem>
+        </Select>
         {testMode &&
           <>
             <p>Guess: {JSON.stringify(guess, 0, 2)}</p>

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useContext } from "react";
 import styles from "./Board.module.css";
-import { playNote, playSequence, playCelebrationSequence, playSequenceFrenchHorn } from "./helpers/playMusic";
+import { playNote, playSequence, playCelebrationSequence } from "./helpers/playMusic";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
@@ -16,8 +16,8 @@ import ModalStats from './ModalStats';
 import MidnightContext from './contexts/MidnightContext';
 import getNote from './helpers/getNote'
 import ShareResults from './ShareResults'
-import MenuItem from '@mui/material/MenuItem';
-import Select from '@mui/material/Select';
+import InputLabel from '@mui/material/InputLabel';
+import NativeSelect from '@mui/material/NativeSelect';
 
 
 function Board({ answer, testMode }) {
@@ -34,6 +34,7 @@ function Board({ answer, testMode }) {
     })
   );
   const [playTuneTries, setPlayTuneTries] = useState(3);
+  const [instrument, setInstrument] = useState("acoustic_grand_piano")
   const [difficultyMode, setDifficultyMode] = useState('normal')
   const [isOpen, setIsOpen] = useState(false);
   const [showStatsModal, setShowStatsModal] = useState(false);
@@ -111,7 +112,7 @@ function Board({ answer, testMode }) {
 
       if (guessArr.join("") === answerArr.join("")) {
         setGameWon(true);
-        playCelebrationSequence(answer, volume);
+        playCelebrationSequence(instrument, answer, volume);
         setShareOutput(shareOutput.slice(0, currentRow + 1));
         document
           .querySelectorAll(`input[name^="note-${currentRow}"]`)
@@ -126,13 +127,13 @@ function Board({ answer, testMode }) {
         setError("Please fill out all the notes in the row before submitting.");
         return;
       } else if (guessAttempts === 6) {
-        playCelebrationSequence(answer, volume);
+        playCelebrationSequence(instrument, answer, volume);
         setMessage(`Better luck next time! The song was '${answer["song"]}'.\n
         Notes: ${answerArr.join("").replace(/\./g, "")}`);
         updateStats(false);
       } else {
         /*If user has submitted 6 notes, play the notes when they submit*/
-        playSequence(answer, guess, currentRow, volume);
+        playSequence(instrument, answer, guess, currentRow, volume);
         /*Increment the row*/
         setCurrentRow(currentRow + 1);
         setError("Please try again");
@@ -215,7 +216,7 @@ function Board({ answer, testMode }) {
           }
 
           /*Play the note in the same octave as the corresponding answer*/
-          playNote(note, answer, guess[currentRow].length / 2, volume);
+          playNote(instrument, note, answer, guess[currentRow].length / 2, volume);
           //setError("");
           break;
         case event.key === "Enter":
@@ -297,10 +298,10 @@ function Board({ answer, testMode }) {
                   e.preventDefault();
                   setError("You've maxed out the number of times you can play the tune")
                   return;
-                } 
-                setPlayTuneTries(playTuneTries-1);
+                }
+                setPlayTuneTries(playTuneTries - 1);
               }
-              playSequence(answer, undefined, undefined, volume);
+              playSequence(instrument, answer, undefined, undefined, volume);
             }
             }>
             <FontAwesomeIcon icon={faPlay} /> Play the tune {difficultyMode === 'difficult' && `- ${playTuneTries} plays left`}</button>
@@ -332,7 +333,7 @@ function Board({ answer, testMode }) {
                         if (guess[row].length === 0) {
                           setError("Please guess a note.")
                         } else {
-                          playSequence(answer, guess, row, volume);
+                          playSequence(instrument, answer, guess, row, volume);
                         }
                       }}
                     >
@@ -368,24 +369,46 @@ function Board({ answer, testMode }) {
       <Grid item xl={4} lg={5} md={7} className={styles.right}>
         <PianoNew handlePianoPress={handlePianoPress} octave={octave} hasFlats={answer?.hasFlats} />
         <hr />
-        <p><strong>Difficulty Mode (beta)</strong></p>
-        {/* <select onChange={(e) => setDifficultyMode(e.target.value)} className={styles.difficultyMode}>
-          <option value="normal">Normal</option>
-          <option value="difficult">Difficult - the "play my guess" buttons are gone</option>
-          <option value="tricky">Tricky - we play the tune in French Horn; you guess the notes in piano</option>
-        </select> */}
-        <Select
-          labelId="difficulty-level"
-          id="difficulty-level"
-          label="Difficulty Level"
-          defaultValue="normal"
-          onChange={(e) => setDifficultyMode(e.target.value)}
-          className={styles.difficultyMode}
-          sx={{fontSize: '1.6rem'}}
-        >
-          <MenuItem value="normal">Normal</MenuItem>
-          <MenuItem value="difficult">Difficult - play tune up to 3 times and the "play my guess" buttons are gone</MenuItem>
-        </Select>
+        <section className={styles.settings}>
+          <div>
+            <InputLabel variant="standard" htmlFor="instrument">
+              Instrument
+            </InputLabel>
+            <NativeSelect
+              defaultValue="acoustic_grand_piano"
+              inputProps={{
+                name: 'instrument',
+                id: 'instrument',
+              }}
+              onChange={(e) => setInstrument(e.target.value)}
+              sx={{ fontSize: '1.6rem', mr: '2em' }}
+            >
+              <option value="acoustic_grand_piano">Piano</option>
+              <option value="choir_aahs">Choir</option>
+              <option value="flute">Flute</option>
+              <option value="french_horn">French Horn</option>
+              <option value="acoustic_guitar_steel">Guitar</option>
+              <option value="violin">Violin</option>
+            </NativeSelect>
+          </div>
+          <div>
+            <InputLabel variant="standard" htmlFor="difficulty">
+              Difficulty
+            </InputLabel>
+            <NativeSelect
+              defaultValue="normal"
+              inputProps={{
+                name: 'difficulty',
+                id: 'difficulty',
+              }}
+              onChange={(e) => setDifficultyMode(e.target.value)}
+              sx={{ fontSize: '1.6rem' }}
+            >
+              <option value="normal">Normal</option>
+              <option value="difficult">Hard</option>
+            </NativeSelect>
+          </div>
+        </section>
         {testMode &&
           <>
             <p>Guess: {JSON.stringify(guess, 0, 2)}</p>

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -372,7 +372,7 @@ function Board({ answer, testMode }) {
         <section className={styles.settings}>
           <div>
             <InputLabel variant="standard" htmlFor="instrument">
-              Instrument
+              Instrument {instrument}
             </InputLabel>
             <NativeSelect
               defaultValue="acoustic_grand_piano"
@@ -389,6 +389,7 @@ function Board({ answer, testMode }) {
               <option value="french_horn">French Horn</option>
               <option value="acoustic_guitar_steel">Guitar</option>
               <option value="violin">Violin</option>
+              <option value="bird_tweet">Bird Tweet</option>
             </NativeSelect>
           </div>
           <div>

--- a/src/Board.module.css
+++ b/src/Board.module.css
@@ -121,6 +121,12 @@ select.difficultyMode {
   display: none;
 }
 
+.settings {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 5em;
+}
+
 
 @media (min-width: 600px) {
   .board input {

--- a/src/Board.module.css
+++ b/src/Board.module.css
@@ -17,13 +17,16 @@ form .row {
 }
 
 button.action {
-  margin: 0px auto 10px;
+  margin: 0px auto;
 }
 
 button.submit {
   margin: 10px auto;
 }
 
+.board {
+  margin-top: 10px;
+}
 .board input {
   width: 3.1rem;
   height: 3.1rem;

--- a/src/helpers/playMusic.js
+++ b/src/helpers/playMusic.js
@@ -1,39 +1,9 @@
 import { Soundfont } from "smplr";
 
 const context = new AudioContext();
-const piano = new Soundfont(context, { instrument: "acoustic_grand_piano" });
-const frenchHorn = new Soundfont(context, { instrument: "french_horn" });
 
-/**
- * Plays a sequence of notes in french horn
- * @params {object} answer
- * @params {array} guess
- * @params {integer} currentRow
- * @return 
- */
- export function playSequenceFrenchHorn(answer, guess, currentRow, volume) {
-   //console.log('====answer and guess and currentRow, volume', answer, guess, currentRow, volume)
-   //Stop any previous melodies from playing
-   piano.stop();
-   frenchHorn.stop();
-   frenchHorn.output.setVolume(volume * 35);
-   frenchHorn.loaded().then(() => {
-       const now = context.currentTime;
-
-       answer.sequence.slice(0, 6).forEach((note, i) => {
-           const transformedNote = guess !== undefined && guess[currentRow][i*2] !== '' ? guess[currentRow].slice(i*2, 2*(i+1)).split('.')[0] + note.slice(-1) : note;
-           //console.log('====transformedNote', transformedNote) 
-           frenchHorn.start(
-               {
-                   note: transformedNote,
-                   time: now + answer.duration.slice(0, i).reduce((a, b) => a + b, 0) / 4,
-                   duration: answer.duration[i] / 4
-               }
-           );
-       });
-   })
-
-   return;
+function getInstrument(selectedInstrument) {
+    return new Soundfont(context, {instrument: selectedInstrument});
 }
 
 /**
@@ -43,18 +13,19 @@ const frenchHorn = new Soundfont(context, { instrument: "french_horn" });
  * @params {integer} currentRow
  * @return 
  */
-export function playSequence(answer, guess, currentRow, volume) {
+export function playSequence(selectedInstrument, answer, guess, currentRow, volume) {
      //console.log('====answer and guess and currentRow, volume', answer, guess, currentRow, volume)
     //Stop any previous melodies from playing
-    piano.stop();
-    piano.output.setVolume(volume * 35);
-    piano.loaded().then(() => {
+    const instrument = getInstrument(selectedInstrument)
+    instrument.stop();
+    instrument.output.setVolume(volume * 35);
+    instrument.loaded().then(() => {
         const now = context.currentTime;
 
         answer.sequence.slice(0, 6).forEach((note, i) => {
             const transformedNote = guess !== undefined && guess[currentRow][i*2] !== '' ? guess[currentRow].slice(i*2, 2*(i+1)).split('.')[0] + note.slice(-1) : note;
             //console.log('====transformedNote', transformedNote) 
-            piano.start(
+            instrument.start(
                 {
                     note: transformedNote,
                     time: now + answer.duration.slice(0, i).reduce((a, b) => a + b, 0) / 4,
@@ -75,13 +46,14 @@ export function playSequence(answer, guess, currentRow, volume) {
  * @return 
  */
 
-export function playCelebrationSequence(answer, volume) {
-    piano.output.setVolume(volume * 35);
-    piano.stop();
-    piano.loaded().then(() => {
+export function playCelebrationSequence(selectedInstrument, answer, volume) {
+    const instrument = getInstrument(selectedInstrument)
+    instrument.output.setVolume(volume * 35);
+    instrument.stop();
+    instrument.loaded().then(() => {
         const now = context.currentTime;
         answer.sequence.forEach((note, i) => {
-            piano.start({ note, time: now + answer.duration.slice(0, i).reduce((a, b) => a + b, 0) / 4, duration: answer.duration[i] / 4 });
+            instrument.start({ note, time: now + answer.duration.slice(0, i).reduce((a, b) => a + b, 0) / 4, duration: answer.duration[i] / 4 });
         });
     })
     return;
@@ -95,7 +67,8 @@ export function playCelebrationSequence(answer, volume) {
  * @return 
  */
 
-export function playNote(note, answer, currentNote, volume) {
+export function playNote(selectedInstrument, note, answer, currentNote, volume) {
+    const instrument = getInstrument(selectedInstrument)
     if (currentNote === 6) {
         return;
     }
@@ -103,12 +76,12 @@ export function playNote(note, answer, currentNote, volume) {
     if (note.slice(-1) === ".") {
         note = note[0];
     }
-    piano.output.setVolume(volume * 35);
+    instrument.output.setVolume(volume * 35);
 
-    piano.loaded().then(() => {
+    instrument.loaded().then(() => {
         const octave = answer.sequence[currentNote].slice(-1);
         const now = context.currentTime;
-        piano.start({ note: `${note}${octave}`, time: now, duration: 0.5 });
+        instrument.start({ note: `${note}${octave}`, time: now, duration: 0.5 });
     })
     return;
 }

--- a/src/helpers/playMusic.js
+++ b/src/helpers/playMusic.js
@@ -2,8 +2,17 @@ import { Soundfont } from "smplr";
 
 const context = new AudioContext();
 
-function getInstrument(selectedInstrument) {
-    return new Soundfont(context, {instrument: selectedInstrument});
+const instrumentsObj = {};
+const instrumentsArr = ["acoustic_grand_piano", "violin", "french_horn", "choir_aahs", "acoustic_guitar_steel", "bird_tweet"]
+
+for (let i = 0; i < instrumentsArr.length; i++) {
+    instrumentsObj[instrumentsArr[i]] = new Soundfont(context, { instrument: instrumentsArr[i] });
+}
+
+function stopAll() {
+    instrumentsArr.forEach((instrument) => {
+        instrumentsObj[instrument].stop();
+    })
 }
 
 /**
@@ -14,16 +23,16 @@ function getInstrument(selectedInstrument) {
  * @return 
  */
 export function playSequence(selectedInstrument, answer, guess, currentRow, volume) {
-     //console.log('====answer and guess and currentRow, volume', answer, guess, currentRow, volume)
+    //console.log('====answer and guess and currentRow, volume', answer, guess, currentRow, volume)
     //Stop any previous melodies from playing
-    const instrument = getInstrument(selectedInstrument)
-    instrument.stop();
+    stopAll();
+    const instrument = instrumentsObj[selectedInstrument];
     instrument.output.setVolume(volume * 35);
     instrument.loaded().then(() => {
         const now = context.currentTime;
 
         answer.sequence.slice(0, 6).forEach((note, i) => {
-            const transformedNote = guess !== undefined && guess[currentRow][i*2] !== '' ? guess[currentRow].slice(i*2, 2*(i+1)).split('.')[0] + note.slice(-1) : note;
+            const transformedNote = guess !== undefined && guess[currentRow][i * 2] !== '' ? guess[currentRow].slice(i * 2, 2 * (i + 1)).split('.')[0] + note.slice(-1) : note;
             //console.log('====transformedNote', transformedNote) 
             instrument.start(
                 {
@@ -47,9 +56,10 @@ export function playSequence(selectedInstrument, answer, guess, currentRow, volu
  */
 
 export function playCelebrationSequence(selectedInstrument, answer, volume) {
-    const instrument = getInstrument(selectedInstrument)
+    //Stop any previous melodies from playing
+    stopAll();
+    const instrument = instrumentsObj[selectedInstrument];
     instrument.output.setVolume(volume * 35);
-    instrument.stop();
     instrument.loaded().then(() => {
         const now = context.currentTime;
         answer.sequence.forEach((note, i) => {
@@ -68,7 +78,11 @@ export function playCelebrationSequence(selectedInstrument, answer, volume) {
  */
 
 export function playNote(selectedInstrument, note, answer, currentNote, volume) {
-    const instrument = getInstrument(selectedInstrument)
+    //Stop any previous melodies from playing
+    stopAll();
+    const instrument = instrumentsObj[selectedInstrument];
+    instrument.output.setVolume(volume * 35);
+
     if (currentNote === 6) {
         return;
     }
@@ -76,7 +90,6 @@ export function playNote(selectedInstrument, note, answer, currentNote, volume) 
     if (note.slice(-1) === ".") {
         note = note[0];
     }
-    instrument.output.setVolume(volume * 35);
 
     instrument.loaded().then(() => {
         const octave = answer.sequence[currentNote].slice(-1);

--- a/src/helpers/playMusic.js
+++ b/src/helpers/playMusic.js
@@ -3,7 +3,7 @@ import { Soundfont } from "smplr";
 const context = new AudioContext();
 
 const instrumentsObj = {};
-const instrumentsArr = ["acoustic_grand_piano", "violin", "french_horn", "choir_aahs", "acoustic_guitar_steel", "bird_tweet"]
+const instrumentsArr = ["acoustic_grand_piano", "violin", "french_horn", "choir_aahs", "acoustic_guitar_steel", "bird_tweet", "flute"]
 
 for (let i = 0; i < instrumentsArr.length; i++) {
     instrumentsObj[instrumentsArr[i]] = new Soundfont(context, { instrument: instrumentsArr[i] });


### PR DESCRIPTION
## Description
This PR resolves #33 

- [x] Support instrument selection
- [x] Remove "tricky" mode and support only 3 plays under "hard" mode 

## Before
<img width="1728" alt="image" src="https://github.com/lpatmo/musical-wordle/assets/4512699/72e804e9-7eb6-4d15-b0e1-d155f31b0bf3">
<img width="227" alt="image" src="https://github.com/lpatmo/musical-wordle/assets/4512699/af9b0eb3-81e0-479a-b4b1-9903e6162885">


## After

<img width="1333" alt="image" src="https://github.com/lpatmo/musical-wordle/assets/4512699/77de0941-80a6-4ecf-bd29-24bb018159b1">
<img width="250" alt="image" src="https://github.com/lpatmo/musical-wordle/assets/4512699/099b36db-d0cf-406f-838b-01c7793ec014">
