### PR TITLE
Easy mode bug fix if first note is a sharp or flat

### DIFF
--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -306,7 +306,7 @@ function Board({ answer, testMode }) {
             if (answer.sequence[0][1] !== '#' && answer.sequence[0][1] !== 'b') {
               return answer.sequence[0][0] + '.'
             } else {
-              return answer.sequence.slice(0,2);
+              return answer.sequence[0].slice(0,2);
             } 
           });
           setGuess(updatedGuess);


### PR DESCRIPTION
Bug: 

<img width="1291" alt="image" src="https://github.com/lpatmo/musical-wordle/assets/4512699/f9deb32a-bbd5-41b2-aa1c-88c295799b7a">
