### PR TITLE
Issue #180 - Mobile sounds

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,7 @@ function App() {
   const [answer, setAnswer] = useState();
   const [volume, setVolume] = useState(3);
   const [isMidnight, setIsMidnight] = useState(false);
-  const [mobileOrSafari, setMobileOrSafari] = useState(false);
+ // const [mobileOrSafari, setMobileOrSafari] = useState(false);
   const [testMode, setTestMode] = useState(false);
   const [showStats, setShowStats] = useState(false);
   const resetBoardRef = useRef(null);
@@ -107,7 +107,7 @@ function App() {
           </header>
           <div className="App-body">
             {showStats && <ModalStats setIsOpen={setShowStats} />}
-            {mobileOrSafari ? <p className="error">Sorry, this game is not available on Safari or on mobile devices.</p> : <>
+            {/*mobileOrSafari ? <p className="error">Sorry, this game is not available on Safari or on mobile devices.</p> : <>
               <Box className="mobileHide">
                 <Stack spacing={3} direction="row" alignItems="center" className="audioSettings">
                   <VolumeDown onClick={handleMute} className="muteVolume" /> <Slider aria-label="Volume" value={volume} onChange={handleVolume} min={0} max={6} /> <VolumeUp />
@@ -121,7 +121,7 @@ function App() {
                 </Stack>
 
               </Box>
-            </>}
+            </>*/}
           </div>
         </div>
         <footer>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -107,7 +107,8 @@ function App() {
           </header>
           <div className="App-body">
             {showStats && <ModalStats setIsOpen={setShowStats} />}
-            {/*mobileOrSafari ? <p className="error">Sorry, this game is not available on Safari or on mobile devices.</p> : <>
+            {/*mobileOrSafari ? <p className="error">Sorry, this game is not available on Safari or on mobile devices.</p> : <>*/
+              <>
               <Box className="mobileHide">
                 <Stack spacing={3} direction="row" alignItems="center" className="audioSettings">
                   <VolumeDown onClick={handleMute} className="muteVolume" /> <Slider aria-label="Volume" value={volume} onChange={handleVolume} min={0} max={6} /> <VolumeUp />
@@ -121,7 +122,7 @@ function App() {
                 </Stack>
 
               </Box>
-            </>*/}
+            </>}
           </div>
         </div>
         <footer>

--- a/src/helpers/playMusic.js
+++ b/src/helpers/playMusic.js
@@ -95,7 +95,9 @@ export function playCelebrationSequence(selectedInstrument, answer, volume) {
 export function playNote(selectedInstrument, note, answer, currentNote, numberTiles, volume, octave) {
     //Stop any previous melodies from playing
     stopAll();
+    if (window.navigator.audioSession){
     window.navigator.audioSession.type = "playback";
+}
     const instrument = instrumentsObj[selectedInstrument];
     instrument.output.setVolume(volume * 35);
 

--- a/src/helpers/playMusic.js
+++ b/src/helpers/playMusic.js
@@ -95,6 +95,7 @@ export function playCelebrationSequence(selectedInstrument, answer, volume) {
 export function playNote(selectedInstrument, note, answer, currentNote, numberTiles, volume, octave) {
     //Stop any previous melodies from playing
     stopAll();
+    window.navigator.audioSession.type = "playback";
     const instrument = instrumentsObj[selectedInstrument];
     instrument.output.setVolume(volume * 35);
 


### PR DESCRIPTION
This PR resolves #180, allowing mobile devices to play audio.

## Before
Users could not detect audio on mobile devices. The issue was set aside for later in #53.

## After
Audio seems to be audible on mobile devices now.

## Implementation Details 
Changed `navigator.audioSession.type` to `playback` instead of the default behavior, which was causing the issue on mobile devices.
Removed the `mobileOrSafari` state.
